### PR TITLE
Wrap the sample SRO output to make it a full document

### DIFF
--- a/test-outputs/sro-measures.html
+++ b/test-outputs/sro-measures.html
@@ -1,3 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" />
+
+<title>Test output</title>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+
+<style type="text/css">body {margin: 0;}</style>
+<style type="text/css">a {background-color: blue;}</style>
+
+</head>
+
+<body>
+
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -864,5 +880,7 @@ Total patients: 0.01M (0.01M events)
 </div>
 
 </div>
- 
 
+</body>
+
+</html>


### PR DESCRIPTION
Seems that the basic format doesn't include `<html>`, `<body>` etc
tags. Not yet sure whether that is really how it's going to work. I'm
adding them manually here so we can get on with working out the
styling -- we can always change the import code later to cope with
their absence.